### PR TITLE
Get latest dnsmasq stable release version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,10 +8,8 @@ jobs:
   check-and-update:
     name: Check and update Dnsmasq release
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Get latest Dnsmasq release version
         run: |
           git clone git://thekelleys.org.uk/dnsmasq.git
@@ -20,14 +18,12 @@ jobs:
           # Trim leading 'v' in semantic version
           new_version=${new_version:1}
           echo "NEW_VERSION=$(echo $new_version)" >> $GITHUB_ENV
-
       - name: Update Docker image version
         run: |
           current_version=$(cat VERSION)
           for f in VERSION Dockerfile docker-compose.yml; do
             sed -i "s/${current_version}/${{env.NEW_VERSION}}/g" "$f"
           done
-
       - name: Send pull request to update to new version
         uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,18 +16,12 @@ jobs:
         run: |
           git clone git://thekelleys.org.uk/dnsmasq.git
           cd dnsmasq
-          new_version=$(git describe --tags --abbrev=0)
+          new_version=$(git describe --abbrev=0 --exclude '*rc*' --exclude '*test*')
           # Trim leading 'v' in semantic version
           new_version=${new_version:1}
-          stable_release=true
-          case $new_version in
-            *rc*|*test*) stable_release=false;;
-          esac
           echo "NEW_VERSION=$(echo $new_version)" >> $GITHUB_ENV
-          echo "STABLE_RELEASE=$(echo $stable_release)" >> $GITHUB_ENV
 
       - name: Update Docker image version
-        if: env.STABLE_RELEASE == 'true'
         run: |
           current_version=$(cat VERSION)
           for f in VERSION Dockerfile docker-compose.yml; do
@@ -35,7 +29,6 @@ jobs:
           done
 
       - name: Send pull request to update to new version
-        if: env.STABLE_RELEASE == 'true'
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Update to ${{ env.NEW_VERSION }}


### PR DESCRIPTION
The current version of the update workflow would fail to detect the latest stable version of Dnsmasq if the author creates a non-stable release before the update workflow is triggered (currently once a week). This PR fixes this issue.